### PR TITLE
Implement @conda decorator for executing python functions in specific environments

### DIFF
--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -3,3 +3,4 @@ channels:
 dependencies:
 - python
 - conda =24.7.1
+- executorlib =0.0.2

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -48,7 +48,7 @@ jobs:
       run: |
         pip install versioneer[toml]==0.29
         pip install . --no-deps --no-build-isolation
-        conda create -y -n py312 python=3.12.1
+        conda create -y -n py312 python=3.12.1 conda=24.7.1
         conda activate py312
         pip install versioneer[toml]==0.29
         pip install . --no-deps --no-build-isolation

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -50,6 +50,7 @@ jobs:
         pip install . --no-deps --no-build-isolation
         conda create -y -n py312 python=3.12.1
         conda activate py312
+        pip install versioneer[toml]==0.29
         pip install . --no-deps --no-build-isolation
         conda deactivate
         python -m unittest discover tests

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -49,4 +49,7 @@ jobs:
         pip install versioneer[toml]==0.29
         pip install . --no-deps --no-build-isolation
         conda create -y -n py312 python=3.12.1
+        conda activate py312
+        pip install . --no-deps --no-build-isolation
+        conda deactivate
         python -m unittest discover tests

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -48,7 +48,7 @@ jobs:
       run: |
         pip install versioneer[toml]==0.29
         pip install . --no-deps --no-build-isolation
-        conda create -y -n py312 python=3.12.1 conda=24.7.1
+        conda create -y -n py312 python=3.12.1 conda=24.7.1 executorlib=0.0.2
         conda activate py312
         pip install versioneer[toml]==0.29
         pip install . --no-deps --no-build-isolation

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Create a new conda environment - in this example a conda environment for Python 
 conda create -n py312 python=3.12 
 ```
 
+### Subprocess Interface
 Open a python shell in your base environment where `conda_subprocess` is installed and execute `python --version` in the
 `py312` environment:
 ```python
@@ -62,6 +63,20 @@ from conda_subprocess import Popen
 process = Popen(["python", "--version"], stdout=PIPE, prefix_name="py312")
 process.communicate()
 >>> (b'Python 3.12.1\n', None)
+```
+
+### Decorator 
+In analogy to the subprocess interface the `conda_subprocess` also introduces the `@conda` decorator to 
+execute python functions in a separate conda environment:
+```python
+from conda_subprocess.decorator import conda
+
+@conda(prefix_name="py312")
+def add_function(parameter_1, parameter_2):
+    return parameter_1 + parameter_2
+
+add_function(parameter_1=1, parameter_2=2)
+>>> 3
 ```
 
 ## Remarks

--- a/conda_subprocess/decorator.py
+++ b/conda_subprocess/decorator.py
@@ -1,19 +1,19 @@
+import subprocess
 from concurrent.futures import Future
 from socket import gethostname
-import subprocess
 from typing import Optional
 
 try:
-    from executorlib.shared.interface import SubprocessInterface
-    from executorlib.shared.executor import get_command_path
     from executorlib.shared.communication import SocketInterface
+    from executorlib.shared.executor import get_command_path
+    from executorlib.shared.interface import SubprocessInterface
 except ImportError:
     pass
 
 from conda_subprocess.process import Popen
 
 
-def conda(prefix_name: Optional[str]=None, prefix_path: Optional[str]=None):
+def conda(prefix_name: Optional[str] = None, prefix_path: Optional[str] = None):
     def conda_function(funct):
         def function_wrapped(*args, **kwargs):
             task_future = Future()
@@ -39,9 +39,12 @@ def conda(prefix_name: Optional[str]=None, prefix_path: Optional[str]=None):
                 prefix_name=prefix_name,
                 prefix_path=prefix_path,
             )
-            task_future.set_result(interface.send_and_receive_dict(input_dict=task_dict))
+            task_future.set_result(
+                interface.send_and_receive_dict(input_dict=task_dict)
+            )
             interface.shutdown(wait=True)
             return task_future.result()
 
         return function_wrapped
+
     return conda_function

--- a/conda_subprocess/decorator.py
+++ b/conda_subprocess/decorator.py
@@ -1,0 +1,47 @@
+from concurrent.futures import Future
+from socket import gethostname
+import subprocess
+from typing import Optional
+
+try:
+    from executorlib.shared.interface import SubprocessInterface
+    from executorlib.shared.executor import get_command_path
+    from executorlib.shared.communication import SocketInterface
+except ImportError:
+    pass
+
+from conda_subprocess.process import Popen
+
+
+def conda(prefix_name: Optional[str]=None, prefix_path: Optional[str]=None):
+    def conda_function(funct):
+        def function_wrapped(*args, **kwargs):
+            task_future = Future()
+            task_dict = {
+                "fn": funct,
+                "args": args,
+                "kwargs": kwargs,
+                "resource_dict": {"cores": 1},
+            }
+            interface = SocketInterface(interface=SubprocessInterface(cores=1))
+            command_lst = [
+                "python",
+                get_command_path(executable="interactive_serial.py"),
+                "--host",
+                gethostname(),
+                "--zmqport",
+                str(interface.bind_to_random_port()),
+            ]
+            interface._interface._process = Popen(
+                args=interface._interface.generate_command(command_lst=command_lst),
+                cwd=interface._interface._cwd,
+                stdin=subprocess.DEVNULL,
+                prefix_name=prefix_name,
+                prefix_path=prefix_path,
+            )
+            task_future.set_result(interface.send_and_receive_dict(input_dict=task_dict))
+            interface.shutdown(wait=True)
+            return task_future.result()
+
+        return function_wrapped
+    return conda_function

--- a/conda_subprocess/decorator.py
+++ b/conda_subprocess/decorator.py
@@ -10,7 +10,7 @@ from executorlib.shared.interface import SubprocessInterface
 from conda_subprocess.process import Popen
 
 
-def conda(prefix_name: Optional[str] = None, prefix_path: Optional[str] = None):
+def conda(prefix_name: Optional[str] = None, prefix_path: Optional[str] = None, hostname_localhost: bool = False):
     def conda_function(funct):
         def function_wrapped(*args, **kwargs):
             task_future = Future()
@@ -21,14 +21,10 @@ def conda(prefix_name: Optional[str] = None, prefix_path: Optional[str] = None):
                 "resource_dict": {"cores": 1},
             }
             interface = SocketInterface(interface=SubprocessInterface(cores=1))
-            command_lst = [
-                "python",
-                get_command_path(executable="interactive_serial.py"),
-                "--host",
-                gethostname(),
-                "--zmqport",
-                str(interface.bind_to_random_port()),
-            ]
+            command_lst = ["python", get_command_path(executable="interactive_serial.py")]
+            if not hostname_localhost:
+                command_lst += ["--host", gethostname()]
+            command_lst += ["--zmqport", str(interface.bind_to_random_port())]
             interface._interface._process = Popen(
                 args=interface._interface.generate_command(command_lst=command_lst),
                 cwd=interface._interface._cwd,

--- a/conda_subprocess/decorator.py
+++ b/conda_subprocess/decorator.py
@@ -3,12 +3,9 @@ from concurrent.futures import Future
 from socket import gethostname
 from typing import Optional
 
-try:
-    from executorlib.shared.communication import SocketInterface
-    from executorlib.shared.executor import get_command_path
-    from executorlib.shared.interface import SubprocessInterface
-except ImportError:
-    pass
+from executorlib.shared.communication import SocketInterface
+from executorlib.shared.executor import get_command_path
+from executorlib.shared.interface import SubprocessInterface
 
 from conda_subprocess.process import Popen
 

--- a/conda_subprocess/decorator.py
+++ b/conda_subprocess/decorator.py
@@ -10,7 +10,11 @@ from executorlib.shared.interface import SubprocessInterface
 from conda_subprocess.process import Popen
 
 
-def conda(prefix_name: Optional[str] = None, prefix_path: Optional[str] = None, hostname_localhost: bool = False):
+def conda(
+    prefix_name: Optional[str] = None,
+    prefix_path: Optional[str] = None,
+    hostname_localhost: bool = False,
+):
     def conda_function(funct):
         def function_wrapped(*args, **kwargs):
             task_future = Future()
@@ -21,7 +25,10 @@ def conda(prefix_name: Optional[str] = None, prefix_path: Optional[str] = None, 
                 "resource_dict": {"cores": 1},
             }
             interface = SocketInterface(interface=SubprocessInterface(cores=1))
-            command_lst = ["python", get_command_path(executable="interactive_serial.py")]
+            command_lst = [
+                "python",
+                get_command_path(executable="interactive_serial.py"),
+            ]
             if not hostname_localhost:
                 command_lst += ["--host", gethostname()]
             command_lst += ["--zmqport", str(interface.bind_to_random_port())]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,11 @@ dynamic = ["version"]
 [project.urls]
 Repository = "https://github.com/pyiron/conda_subprocess"
 
+[project.optional-dependencies]
+executorlib = [
+    "executorlib==0.0.2",
+]
+
 [tool.setuptools.packages.find]
 include = ["conda_subprocess*"]
 

--- a/tests/test_conda_function.py
+++ b/tests/test_conda_function.py
@@ -5,9 +5,12 @@ import subprocess
 import sys
 import unittest
 
-from executorlib.shared.interface import SubprocessInterface
-from executorlib.shared.executor import cloudpickle_register, get_command_path
-from executorlib.shared.communication import SocketInterface
+try:
+    from executorlib.shared.interface import SubprocessInterface
+    from executorlib.shared.executor import cloudpickle_register, get_command_path
+    from executorlib.shared.communication import SocketInterface
+except ImportError:
+    pass
 
 import conda_subprocess
 

--- a/tests/test_conda_function.py
+++ b/tests/test_conda_function.py
@@ -19,80 +19,25 @@ def add_function(parameter_1, parameter_2):
     )
 
 
-def execute_parallel_tasks(
-    future_queue,
-    cores,
-    interface_class,
-    hostname_localhost=False,
-    prefix_name=None,
-    prefix_path=None,
-    **kwargs,
-) -> None:
-    """
-    Execute a single tasks in parallel using the message passing interface (MPI).
-
-    Args:
-       future_queue (queue.Queue): task queue of dictionary objects which are submitted to the parallel process
-       cores (int): defines the total number of MPI ranks to use
-       interface_class (BaseInterface): Interface to start process on selected compute resources
-       hostname_localhost (boolean): use localhost instead of the hostname to establish the zmq connection. In the
-                                     context of an HPC cluster this essential to be able to communicate to an
-                                     Executor running on a different compute node within the same allocation. And
-                                     in principle any computer should be able to resolve that their own hostname
-                                     points to the same address as localhost. Still MacOS >= 12 seems to disable
-                                     this look up for security reasons. So on MacOS it is required to set this
-                                     option to true
-       prefix_name (str): name of the conda environment to initialize
-       prefix_path (str): path of the conda environment to initialize
-    """
-    interface = interface_bootup(
-        command_lst=["python", get_command_path(executable="interactive_serial.py")],
-        connections=interface_class(cores=cores, **kwargs),
-        hostname_localhost=hostname_localhost,
-        prefix_path=prefix_path,
-        prefix_name=prefix_name,
-    )
-    while True:
-        task_dict = future_queue.get()
-        if "shutdown" in task_dict.keys() and task_dict["shutdown"]:
-            interface.shutdown(wait=task_dict["wait"])
-            future_queue.task_done()
-            future_queue.join()
-            break
-        elif "fn" in task_dict.keys() and "future" in task_dict.keys():
-            f = task_dict.pop("future")
-            if f.set_running_or_notify_cancel():
-                try:
-                    f.set_result(interface.send_and_receive_dict(input_dict=task_dict))
-                except Exception as thread_exception:
-                    interface.shutdown(wait=True)
-                    future_queue.task_done()
-                    f.set_exception(exception=thread_exception)
-                    raise thread_exception
-                else:
-                    future_queue.task_done()
-
-
 class TestCondaFunction(TestCase):
     def test_conda_function(self):
         cloudpickle_register(ind=1)
         task_queue = queue.Queue()
         task_future = Future()
-        task_queue.put(
-            {
-                "fn": add_function,
-                "args": (),
-                "kwargs": {"parameter_1": 1, "parameter_2": 2},
-                "future": task_future,
-                "resource_dict": {"cores": 1},
-            }
-        )
+        task_dict = {
+            "fn": add_function,
+            "args": (),
+            "kwargs": {"parameter_1": 1, "parameter_2": 2},
+            "resource_dict": {"cores": 1},
+        }
         task_queue.put({"shutdown": True, "wait": True})
-        execute_parallel_tasks(
-            future_queue=task_queue,
-            interface_class=SubprocessInterface,
-            cores=1,
+        interface = interface_bootup(
+            command_lst=["python", get_command_path(executable="interactive_serial.py")],
+            connections=SubprocessInterface(cores=1),
             hostname_localhost=False,
+            prefix_path=None,
             prefix_name="py312",
         )
+        task_future.set_result(interface.send_and_receive_dict(input_dict=task_dict))
+        interface.shutdown(wait=True)
         self.assertEqual(task_future.result(), 18)

--- a/tests/test_conda_function.py
+++ b/tests/test_conda_function.py
@@ -1,6 +1,7 @@
 from concurrent.futures import Future
 import queue
-from unittest import TestCase
+import sys
+from unittest import TestCase, skipIf
 from executorlib.shared.interface import SubprocessInterface
 from executorlib.shared.executor import cloudpickle_register, get_command_path
 from executorlib.shared.communication import interface_bootup
@@ -15,6 +16,7 @@ def add_function(parameter_1, parameter_2):
     )
 
 
+skipIf(sys.version_info.minor != 12, "Test environment has to be Python 3.12 for consistency.")
 class TestCondaFunction(TestCase):
     def test_conda_function(self):
         cloudpickle_register(ind=1)
@@ -40,5 +42,5 @@ class TestCondaFunction(TestCase):
         task_future.set_result(interface.send_and_receive_dict(input_dict=task_dict))
         interface.shutdown(wait=True)
         number, prefix = task_future.result()
-        print(prefix)
+        self.assertEqual(prefix[-5:], "py312")
         self.assertEqual(number, 3)

--- a/tests/test_conda_function.py
+++ b/tests/test_conda_function.py
@@ -16,10 +16,10 @@ def execute_parallel_tasks(
     future_queue,
     cores,
     interface_class,
-    hostname_localhost,
-    init_function,
-    prefix_name,
-    prefix_path,
+    hostname_localhost=False,
+    init_function=None,
+    prefix_name=None,
+    prefix_path=None,
     **kwargs,
 ) -> None:
     """

--- a/tests/test_conda_function.py
+++ b/tests/test_conda_function.py
@@ -1,15 +1,75 @@
 from concurrent.futures import Future
 import queue
 from unittest import TestCase
-from executorlib.shared.executor import execute_parallel_tasks
 from executorlib.shared.interface import SubprocessInterface
 from executorlib.shared.executor import cloudpickle_register
+from executorlib.shared.communication import interface_bootup
 
 
 def add_function(parameter_1, parameter_2):
     import sys
 
     return parameter_1 + parameter_2 + sys.version_info.major + sys.version_info.minor
+
+
+def execute_parallel_tasks(
+    future_queue,
+    cores,
+    interface_class,
+    hostname_localhost,
+    init_function,
+    prefix_name,
+    prefix_path,
+    **kwargs,
+) -> None:
+    """
+    Execute a single tasks in parallel using the message passing interface (MPI).
+
+    Args:
+       future_queue (queue.Queue): task queue of dictionary objects which are submitted to the parallel process
+       cores (int): defines the total number of MPI ranks to use
+       interface_class (BaseInterface): Interface to start process on selected compute resources
+       hostname_localhost (boolean): use localhost instead of the hostname to establish the zmq connection. In the
+                                     context of an HPC cluster this essential to be able to communicate to an
+                                     Executor running on a different compute node within the same allocation. And
+                                     in principle any computer should be able to resolve that their own hostname
+                                     points to the same address as localhost. Still MacOS >= 12 seems to disable
+                                     this look up for security reasons. So on MacOS it is required to set this
+                                     option to true
+       init_function (callable): optional function to preset arguments for functions which are submitted later
+       prefix_name (str): name of the conda environment to initialize
+       prefix_path (str): path of the conda environment to initialize
+    """
+    interface = interface_bootup(
+        command_lst=["python"],
+        connections=interface_class(cores=cores, **kwargs),
+        hostname_localhost=hostname_localhost,
+        prefix_path=prefix_path,
+        prefix_name=prefix_name,
+    )
+    if init_function is not None:
+        interface.send_dict(
+            input_dict={"init": True, "fn": init_function, "args": (), "kwargs": {}}
+        )
+    while True:
+        task_dict = future_queue.get()
+        if "shutdown" in task_dict.keys() and task_dict["shutdown"]:
+            interface.shutdown(wait=task_dict["wait"])
+            future_queue.task_done()
+            future_queue.join()
+            break
+        elif "fn" in task_dict.keys() and "future" in task_dict.keys():
+            f = task_dict.pop("future")
+            if f.set_running_or_notify_cancel():
+                try:
+                    f.set_result(interface.send_and_receive_dict(input_dict=task_dict))
+                except Exception as thread_exception:
+                    interface.shutdown(wait=True)
+                    future_queue.task_done()
+                    f.set_exception(exception=thread_exception)
+                    raise thread_exception
+                else:
+                    future_queue.task_done()
 
 
 class TestCondaFunction(TestCase):

--- a/tests/test_conda_function.py
+++ b/tests/test_conda_function.py
@@ -1,20 +1,16 @@
-from concurrent.futures import Future
-import queue
-from socket import gethostname
-import subprocess
 import sys
 import unittest
 
 try:
-    from executorlib.shared.interface import SubprocessInterface
-    from executorlib.shared.executor import cloudpickle_register, get_command_path
-    from executorlib.shared.communication import SocketInterface
+    from executorlib.shared.executor import cloudpickle_register
 except ImportError:
     pass
 
-import conda_subprocess
+
+from conda_subprocess.decorator import conda
 
 
+@conda(prefix_name="py312")
 def add_function(parameter_1, parameter_2):
     import os
 
@@ -28,32 +24,6 @@ def add_function(parameter_1, parameter_2):
 class TestCondaFunction(unittest.TestCase):
     def test_conda_function(self):
         cloudpickle_register(ind=1)
-        task_queue = queue.Queue()
-        task_future = Future()
-        task_dict = {
-            "fn": add_function,
-            "args": (),
-            "kwargs": {"parameter_1": 1, "parameter_2": 2},
-            "resource_dict": {"cores": 1},
-        }
-        task_queue.put({"shutdown": True, "wait": True})
-        interface = SocketInterface(interface=SubprocessInterface(cores=1))
-        command_lst = [
-            "python",
-            get_command_path(executable="interactive_serial.py"),
-            "--host",
-            gethostname(),
-            "--zmqport",
-            str(interface.bind_to_random_port()),
-        ]
-        interface._interface._process = conda_subprocess.Popen(
-            args=interface._interface.generate_command(command_lst=command_lst),
-            cwd=interface._interface._cwd,
-            stdin=subprocess.DEVNULL,
-            prefix_name="py312",
-        )
-        task_future.set_result(interface.send_and_receive_dict(input_dict=task_dict))
-        interface.shutdown(wait=True)
-        number, prefix = task_future.result()
+        number, prefix = add_function(parameter_1=1, parameter_2=2)
         self.assertEqual(prefix[-5:], "py312")
         self.assertEqual(number, 3)

--- a/tests/test_conda_function.py
+++ b/tests/test_conda_function.py
@@ -30,7 +30,7 @@ class TestCondaFunction(TestCase):
         execute_parallel_tasks(
             future_queue=task_queue,
             interface_class=SubprocessInterface,
-            max_cores=1,
+            cores=1,
             hostname_localhost=False,
             prefix_name="py312",
         )

--- a/tests/test_conda_function.py
+++ b/tests/test_conda_function.py
@@ -2,7 +2,7 @@ from concurrent.futures import Future
 import queue
 from unittest import TestCase
 from executorlib.shared.interface import SubprocessInterface
-from executorlib.shared.executor import cloudpickle_register
+from executorlib.shared.executor import cloudpickle_register, get_command_path
 from executorlib.shared.communication import interface_bootup
 
 
@@ -41,7 +41,7 @@ def execute_parallel_tasks(
        prefix_path (str): path of the conda environment to initialize
     """
     interface = interface_bootup(
-        command_lst=["python"],
+        command_lst=["python", get_command_path(executable="interactive_serial.py")],
         connections=interface_class(cores=cores, **kwargs),
         hostname_localhost=hostname_localhost,
         prefix_path=prefix_path,

--- a/tests/test_conda_function.py
+++ b/tests/test_conda_function.py
@@ -1,0 +1,36 @@
+from concurrent.futures import Future
+import queue
+from unittest import TestCase
+from executorlib.shared.executor import execute_parallel_tasks
+from executorlib.shared.interface import SubprocessInterface
+from executorlib.shared.executor import cloudpickle_register
+
+
+def add_function(parameter_1, parameter_2):
+    import sys
+    return parameter_1 + parameter_2 + sys.version_info.major + sys.version_info.minor
+
+
+class TestCondaFunction(TestCase):
+    def test_conda_function(self):
+        cloudpickle_register(ind=1)
+        task_queue = queue.Queue()
+        task_future = Future()
+        task_queue.put(
+            {
+                "fn": add_function,
+                "args": (),
+                "kwargs": {"parameter_1": 1, "parameter_2": 2},
+                "future": task_future,
+                "resource_dict": {"cores": 1},
+            }
+        )
+        task_queue.put({"shutdown": True, "wait": True})
+        execute_parallel_tasks(
+            future_queue=task_queue,
+            interface_class=SubprocessInterface(),
+            max_cores=1,
+            hostname_localhost=False,
+            prefix_name="py312",
+        )
+        self.assertEqual(task_future.result(), 18)

--- a/tests/test_conda_function.py
+++ b/tests/test_conda_function.py
@@ -2,12 +2,15 @@ import sys
 import unittest
 
 try:
+    from conda_subprocess.decorator import conda
     from executorlib.shared.executor import cloudpickle_register
 except ImportError:
-    pass
-
-
-from conda_subprocess.decorator import conda
+    def conda(prefix_name=None, prefix_path=None):
+        def wrap_function(funct):
+            def function_out(*args, **kwargs):
+                return None
+            return function_out
+        return wrap_function
 
 
 @conda(prefix_name="py312")

--- a/tests/test_conda_function.py
+++ b/tests/test_conda_function.py
@@ -28,7 +28,7 @@ class TestCondaFunction(TestCase):
         task_queue.put({"shutdown": True, "wait": True})
         execute_parallel_tasks(
             future_queue=task_queue,
-            interface_class=SubprocessInterface(),
+            interface_class=SubprocessInterface,
             max_cores=1,
             hostname_localhost=False,
             prefix_name="py312",

--- a/tests/test_conda_function.py
+++ b/tests/test_conda_function.py
@@ -7,15 +7,11 @@ from executorlib.shared.communication import interface_bootup
 
 
 def add_function(parameter_1, parameter_2):
-    import importlib
-
-    system = importlib.import_module("sys")
+    import os
 
     return (
-        parameter_1
-        + parameter_2
-        + system.version_info.major
-        + system.version_info.minor
+        parameter_1 + parameter_2,
+        os.environ["CONDA_PREFIX"]
     )
 
 
@@ -40,4 +36,6 @@ class TestCondaFunction(TestCase):
         )
         task_future.set_result(interface.send_and_receive_dict(input_dict=task_dict))
         interface.shutdown(wait=True)
-        self.assertEqual(task_future.result(), 18)
+        number, prefix = task_future.result()
+        print(prefix)
+        self.assertEqual(number, 3)

--- a/tests/test_conda_function.py
+++ b/tests/test_conda_function.py
@@ -18,7 +18,10 @@ def add_function(parameter_1, parameter_2):
     return (parameter_1 + parameter_2, os.environ["CONDA_PREFIX"])
 
 
-@unittest.skipIf(sys.version_info.minor != 12, "Test environment has to be Python 3.12 for consistency.")
+@unittest.skipIf(
+    sys.version_info.minor != 12,
+    "Test environment has to be Python 3.12 for consistency.",
+)
 class TestCondaFunction(unittest.TestCase):
     def test_conda_function(self):
         cloudpickle_register(ind=1)

--- a/tests/test_conda_function.py
+++ b/tests/test_conda_function.py
@@ -7,9 +7,10 @@ from executorlib.shared.communication import interface_bootup
 
 
 def add_function(parameter_1, parameter_2):
-    import sys
+    import importlib
+    system = importlib.import_module('sys')
 
-    return parameter_1 + parameter_2 + sys.version_info.major + sys.version_info.minor
+    return parameter_1 + parameter_2 + system.version_info.major + system.version_info.minor
 
 
 def execute_parallel_tasks(
@@ -17,7 +18,6 @@ def execute_parallel_tasks(
     cores,
     interface_class,
     hostname_localhost=False,
-    init_function=None,
     prefix_name=None,
     prefix_path=None,
     **kwargs,
@@ -36,7 +36,6 @@ def execute_parallel_tasks(
                                      points to the same address as localhost. Still MacOS >= 12 seems to disable
                                      this look up for security reasons. So on MacOS it is required to set this
                                      option to true
-       init_function (callable): optional function to preset arguments for functions which are submitted later
        prefix_name (str): name of the conda environment to initialize
        prefix_path (str): path of the conda environment to initialize
     """
@@ -47,10 +46,6 @@ def execute_parallel_tasks(
         prefix_path=prefix_path,
         prefix_name=prefix_name,
     )
-    if init_function is not None:
-        interface.send_dict(
-            input_dict={"init": True, "fn": init_function, "args": (), "kwargs": {}}
-        )
     while True:
         task_dict = future_queue.get()
         if "shutdown" in task_dict.keys() and task_dict["shutdown"]:

--- a/tests/test_conda_function.py
+++ b/tests/test_conda_function.py
@@ -8,9 +8,15 @@ from executorlib.shared.communication import interface_bootup
 
 def add_function(parameter_1, parameter_2):
     import importlib
-    system = importlib.import_module('sys')
 
-    return parameter_1 + parameter_2 + system.version_info.major + system.version_info.minor
+    system = importlib.import_module("sys")
+
+    return (
+        parameter_1
+        + parameter_2
+        + system.version_info.major
+        + system.version_info.minor
+    )
 
 
 def execute_parallel_tasks(


### PR DESCRIPTION
Example: 
```python
from conda_subprocess.decorator import conda

@conda(prefix_name="py312")
def add_function(parameter_1, parameter_2):
    import os
    return (parameter_1 + parameter_2, os.environ["CONDA_PREFIX"])

number, prefix = add_function(parameter_1=1, parameter_2=2)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced testing environment by integrating conda environment management.
	- Added a new dependency (`executorlib`) to support continuous integration.
	- Introduced a test suite to validate functionality within the conda environment.
	- Implemented a decorator to facilitate function execution in a subprocess environment.
	- Updated documentation to clarify usage of the `conda_subprocess` module and its features.

- **Bug Fixes**
	- Improved reliability of tests by ensuring correct Python version and dependencies are utilized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->