### PR TITLE
Test with Python 3.13

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -14,12 +14,15 @@ jobs:
       matrix:
         include:
         - operating-system: macos-latest
-          python-version: '3.12'
+          python-version: '3.13'
 
         - operating-system: ubuntu-latest
-          python-version: '3.12'
+          python-version: '3.13'
 
         - operating-system: windows-latest
+          python-version: '3.13'
+
+        - operating-system: ubuntu-latest
           python-version: '3.12'
 
         - operating-system: ubuntu-latest
@@ -48,7 +51,7 @@ jobs:
       run: |
         pip install versioneer[toml]==0.29
         pip install . --no-deps --no-build-isolation
-        conda create -y -n py312 python=3.12.1 conda=24.7.1 executorlib=0.0.5
+        conda create -y -n py312 python=3.12.1 conda=24.11.2 executorlib=0.0.7
         conda activate py312
         pip install versioneer[toml]==0.29
         pip install . --no-deps --no-build-isolation


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow to use Python 3.13 for macOS, Ubuntu, and Windows testing environments
	- Updated Conda version from 24.7.1 to 24.11.2
	- Updated executorlib package version from 0.0.5 to 0.0.7

<!-- end of auto-generated comment: release notes by coderabbit.ai -->