### PR TITLE
Update conda to 25.1.0

### DIFF
--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -2,5 +2,5 @@ channels:
 - conda-forge
 dependencies:
 - coverage
-- conda =24.11.2
+- conda =25.1.0
 - executorlib =0.0.8

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         pip install versioneer[toml]==0.29
         pip install . --no-deps --no-build-isolation
-        conda create -y -n py312 python=3.12.1 conda=24.7.1 executorlib=0.0.5
+        conda create -y -n py312 python=3.12.1 conda=25.1.0 executorlib=0.0.8
         conda activate py312
         pip install versioneer[toml]==0.29
         pip install . --no-deps --no-build-isolation

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -48,7 +48,7 @@ jobs:
       run: |
         pip install versioneer[toml]==0.29
         pip install . --no-deps --no-build-isolation
-        conda create -y -n py312 python=3.12.1 conda=24.11.2 executorlib=0.0.7
+        conda create -y -n py312 python=3.12.1 conda=25.1.0 executorlib=0.0.8
         conda activate py312
         pip install versioneer[toml]==0.29
         pip install . --no-deps --no-build-isolation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "conda==24.11.2",
+    "conda==25.1.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Conda package version from 24.11.2 to 25.1.0 across multiple configuration files
	- Updated `executorlib` package version from 0.0.5/0.0.7 to 0.0.8 in GitHub Actions workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->