### PR TITLE
Update executorlib version in pipeline to 1.2.0

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -61,7 +61,7 @@ jobs:
       run: |
         pip install versioneer[toml]==0.29
         pip install . --no-deps --no-build-isolation
-        conda create -y -n py313 python=3.13.2 conda=25.3.1 executorlib=1.0.1
+        conda create -y -n py313 python=3.13.2 conda=25.3.1 executorlib=1.2.0
         conda activate py313
         pip install versioneer[toml]==0.29
         pip install . --no-deps --no-build-isolation
@@ -162,7 +162,7 @@ jobs:
       run: |
         pip install versioneer[toml]==0.29
         pip install . --no-deps --no-build-isolation
-        conda create -y -n py313 python=3.13.2 conda=25.3.1 executorlib=1.0.1
+        conda create -y -n py313 python=3.13.2 conda=25.3.1 executorlib=1.2.0
         conda activate py313
         pip install versioneer[toml]==0.29
         pip install . --no-deps --no-build-isolation


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the workflow to use version 1.2.0 of the `executorlib` package in all relevant pipeline jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->