### PR TITLE
Add context for conda

### DIFF
--- a/conda_subprocess/decorator.py
+++ b/conda_subprocess/decorator.py
@@ -90,3 +90,46 @@ def conda(
         return function_wrapped
 
     return conda_function
+
+
+class CondaContext(object):
+    def __init__(self, prefix_name: Optional[str] = None, prefix_path: Optional[str] = None, hostname_localhost: bool = False):
+        self._prefix_name = prefix_name
+        self._prefix_path = prefix_path
+        self._hostname_localhost = hostname_localhost
+        self._interface = None
+
+    def __enter__(self):
+        self._interface = SocketInterface(
+            spawner=CondaSpawner(
+                cores=1,
+                prefix_name=self._prefix_name,
+                prefix_path=self._prefix_path,
+            )
+        )
+        command_lst = [
+            "python",
+            get_command_path(executable="interactive_serial.py"),
+        ]
+        if not self._hostname_localhost:
+            command_lst += ["--host", gethostname()]
+        command_lst += ["--zmqport", str(interface.bind_to_random_port())]
+        self._interface.bootup(command_lst=command_lst)
+        return self
+
+    def __call__(self, fn, /, *args, **kwargs):
+        task_future = Future()
+        task_dict = {
+            "fn": fn,
+            "args": args,
+            "kwargs": kwargs,
+            "resource_dict": {"cores": 1},
+        }
+        task_future.set_result(
+            interface.send_and_receive_dict(input_dict=task_dict)
+        )
+        return task_future.result()
+
+    def __exit__(self, type, value, traceback):
+        if self._interface is not None:
+            self._interface.shutdown(wait=True)

--- a/conda_subprocess/decorator.py
+++ b/conda_subprocess/decorator.py
@@ -92,8 +92,13 @@ def conda(
     return conda_function
 
 
-class CondaContext(object):
-    def __init__(self, prefix_name: Optional[str] = None, prefix_path: Optional[str] = None, hostname_localhost: bool = False):
+class CondaContext:
+    def __init__(
+        self,
+        prefix_name: Optional[str] = None,
+        prefix_path: Optional[str] = None,
+        hostname_localhost: bool = False,
+    ):
         self._prefix_name = prefix_name
         self._prefix_path = prefix_path
         self._hostname_localhost = hostname_localhost
@@ -125,9 +130,7 @@ class CondaContext(object):
             "kwargs": kwargs,
             "resource_dict": {"cores": 1},
         }
-        task_future.set_result(
-            interface.send_and_receive_dict(input_dict=task_dict)
-        )
+        task_future.set_result(interface.send_and_receive_dict(input_dict=task_dict))
         return task_future.result()
 
     def __exit__(self, type, value, traceback):

--- a/conda_subprocess/decorator.py
+++ b/conda_subprocess/decorator.py
@@ -113,7 +113,7 @@ class CondaContext(object):
         ]
         if not self._hostname_localhost:
             command_lst += ["--host", gethostname()]
-        command_lst += ["--zmqport", str(interface.bind_to_random_port())]
+        command_lst += ["--zmqport", str(self._interface.bind_to_random_port())]
         self._interface.bootup(command_lst=command_lst)
         return self
 
@@ -126,7 +126,7 @@ class CondaContext(object):
             "resource_dict": {"cores": 1},
         }
         task_future.set_result(
-            interface.send_and_receive_dict(input_dict=task_dict)
+            self._interface.send_and_receive_dict(input_dict=task_dict)
         )
         return task_future.result()
 

--- a/tests/test_conda_function.py
+++ b/tests/test_conda_function.py
@@ -3,7 +3,7 @@ import sys
 import unittest
 
 try:
-    from conda_subprocess.decorator import conda
+    from conda_subprocess.decorator import conda, CondaContext
     from executorlib import SingleNodeExecutor
     from executorlib.standalone.serialize import cloudpickle_register
 except ImportError:
@@ -72,5 +72,19 @@ class TestCondaFunction(unittest.TestCase):
         with SingleNodeExecutor(max_cores=1, hostname_localhost=True) as exe:
             future = exe.submit(get_exe, 1, 2)
             number, prefix = future.result()
+        self.assertTrue("py313" in prefix.split(os.sep))
+        self.assertEqual(number, 3)
+
+    def test_conda_function_with_context(self):
+        cloudpickle_register(ind=1)
+        with CondaContext(prefix_name="py313") as conda:
+            number, prefix = conda(add_function, 1, 2)
+        self.assertTrue("py313" in prefix.split(os.sep))
+        self.assertEqual(number, 3)
+
+    def test_conda_exe_with_context(self):
+        cloudpickle_register(ind=1)
+        with CondaContext(prefix_name="py313") as conda:
+            number, prefix = conda(get_exe, 1, 2)
         self.assertTrue("py313" in prefix.split(os.sep))
         self.assertEqual(number, 3)


### PR DESCRIPTION
I am not sure if the context manager is more comfortable for the user: 
```python
from conda_subprocess.decorator import CondaContext
 
def add_function(parameter_1, parameter_2):
    return parameter_1 + parameter_2

with CondaContext(prefix_name="py313") as conda:
    number = conda(add_function, 1, 2)
```
The main part I dislike is that every function has to be called with `conda()`. 

In contrast the decorator seems to be more intuitive to me:
```python
from conda_subprocess.decorator import conda
 
@conda(prefix_name="py313")
def add_function(parameter_1, parameter_2):
    return parameter_1 + parameter_2

number = add_function(1, 2)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a context-manager interface to run tasks inside a Conda environment via a with-block, with automatic startup/teardown and optional host/port configuration.

* **Tests**
  * Added test coverage for the new context-managed workflow, verifying task execution results and correct environment selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->