### PR TITLE
Improve documentation: installation instructions and API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,24 @@
 
 Run a subprocess in a different conda environment. 
 
+## Installation
+`conda_subprocess` is available on [PyPI](https://pypi.org/project/conda-subprocess/) and
+[conda-forge](https://anaconda.org/conda-forge/conda_subprocess):
+```commandline
+pip install conda_subprocess
+```
+or
+```commandline
+conda install -c conda-forge conda_subprocess
+```
+The `@conda` decorator additionally requires [`executorlib`](https://github.com/pyiron/executorlib), which can be
+installed via the `executorlib` extra:
+```commandline
+pip install conda_subprocess[executorlib]
+```
+A working `conda` (or `mamba`) installation is required at runtime - `conda_subprocess` locates it via the
+`CONDA_EXE` environment variable, which is set automatically inside an activated conda environment.
+
 ## Example 
 Create a new conda environment - in this example a conda environment for Python 3.12:
 ```commandline
@@ -12,6 +30,14 @@ conda create -n py312 python=3.12
 ```
 
 ### Subprocess Interface
+`conda_subprocess` mirrors the [`subprocess`](https://docs.python.org/3/library/subprocess.html) module
+(`call()`, `check_call()`, `check_output()`, `run()`, `Popen()`) and adds two keyword arguments to all of them
+to select the target environment:
+* `prefix_name` - the name of the target conda environment, e.g. `"py312"`
+* `prefix_path` - the absolute path of the target conda environment, e.g. `"/home/user/mambaforge/envs/py312"`
+
+If neither is given, the currently active conda environment is used, just like with a plain `subprocess` call.
+
 Open a python shell in your base environment where `conda_subprocess` is installed and execute `python --version` in the
 `py312` environment:
 ```python

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ add_function(parameter_1=1, parameter_2=2)
 ## Documentation 
 
 * [conda_subprocess](https://conda-subprocess.readthedocs.io/en/latest/README.html)
+  * [Installation](https://conda-subprocess.readthedocs.io/en/latest/README.html#installation)
   * [Example](https://conda-subprocess.readthedocs.io/en/latest/README.html#example)
   * [Remarks](https://conda-subprocess.readthedocs.io/en/latest/README.html#remarks)
 * [demo](https://conda-subprocess.readthedocs.io/en/latest/demo.html)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,7 +1,14 @@
 Interface
 =========
 
-Documentation of the classes and functions defined in the :code:`conda_subprocess` package.
+Documentation of the classes and functions defined in the :code:`conda_subprocess` package. For an
+introduction with runnable examples, see the `README <README.html>`_ and the `demo notebook <demo.html>`_.
+
+The subprocess-style functions (:code:`call`, :code:`check_call`, :code:`check_output`, :code:`run`,
+:code:`Popen`) mirror their :code:`subprocess` counterparts and add :code:`prefix_name`/:code:`prefix_path`
+keyword arguments to select the target conda environment - see :func:`conda_subprocess.process.Popen` for
+details. The :func:`conda_subprocess.decorator.conda` decorator runs a whole Python function in another
+conda environment instead.
 
 .. autosummary::
    :toctree: _autosummary

--- a/src/conda_subprocess/decorator.py
+++ b/src/conda_subprocess/decorator.py
@@ -9,6 +9,22 @@ from conda_subprocess.process import Popen
 
 
 class CondaSpawner(SubprocessSpawner):
+    """
+    executorlib `SubprocessSpawner` which starts the worker process with
+    `conda_subprocess.Popen()` instead of the regular `subprocess.Popen()`, so the
+    worker runs inside the conda environment selected by `prefix_name`/`prefix_path`.
+
+    Args:
+        cwd (str): Working directory to start the worker process in.
+        cores (int): Number of cores to use for the worker process.
+        openmpi_oversubscribe (bool): Whether to oversubscribe the worker process.
+        threads_per_core (int): Number of threads per core.
+        prefix_name (str): Name of the conda environment the worker process should be
+            executed in.
+        prefix_path (str): Absolute path of the conda environment the worker process
+            should be executed in.
+    """
+
     def __init__(
         self,
         cwd: Optional[str] = None,
@@ -57,6 +73,38 @@ def conda(
     prefix_path: Optional[str] = None,
     hostname_localhost: bool = False,
 ):
+    """
+    Decorator to execute a python function in a different conda environment, built on
+    top of `executorlib`.
+
+    The decorated function (including its arguments and return value) is shipped to a
+    worker process running in the target conda environment via `cloudpickle`, so the
+    target environment's Python minor version must match the one used to define the
+    decorated function.
+
+    Args:
+        prefix_name (str): Name of the conda environment the function should be
+            executed in, e.g. `"py312"`.
+        prefix_path (str): Absolute path of the conda environment the function should
+            be executed in.
+        hostname_localhost (bool): Use `localhost` instead of the system hostname to
+            establish the connection to the worker process. Required in restricted
+            network environments such as containers or HPC login nodes where the
+            hostname cannot be resolved.
+
+    Returns:
+        Callable: Decorator which wraps the given function so it executes in the
+            target conda environment.
+
+    Example:
+        >>> from conda_subprocess.decorator import conda
+        >>> @conda(prefix_name="py312")
+        ... def add_function(parameter_1, parameter_2):
+        ...     return parameter_1 + parameter_2
+        >>> add_function(parameter_1=1, parameter_2=2)
+        3
+    """
+
     def conda_function(funct):
         def function_wrapped(*args, **kwargs):
             task_future = Future()

--- a/src/conda_subprocess/interface.py
+++ b/src/conda_subprocess/interface.py
@@ -12,9 +12,11 @@ def call(*popenargs, timeout=None, **kwargs):
     """Run command with arguments.  Wait for command to complete or
     timeout, then return the returncode attribute.
 
-    The arguments are the same as for the Popen constructor.  Example:
+    The arguments are the same as for the Popen constructor, including the additional
+    `prefix_name`/`prefix_path` keyword arguments used to select the target conda
+    environment (see :func:`conda_subprocess.process.Popen`).  Example:
 
-    retcode = call(["ls", "-l"])
+    retcode = call(["ls", "-l"], prefix_name="py312")
     """
     with Popen(*popenargs, **kwargs) as p:
         try:
@@ -31,9 +33,11 @@ def check_call(*popenargs, **kwargs):
     CalledProcessError.  The CalledProcessError object will have the
     return code in the returncode attribute.
 
-    The arguments are the same as for the call function.  Example:
+    The arguments are the same as for the call function, including the additional
+    `prefix_name`/`prefix_path` keyword arguments used to select the target conda
+    environment.  Example:
 
-    check_call(["ls", "-l"])
+    check_call(["ls", "-l"], prefix_name="py312")
     """
     retcode = call(*popenargs, **kwargs)
     if retcode:
@@ -51,7 +55,9 @@ def check_output(*popenargs, timeout=None, **kwargs):
     CalledProcessError object will have the return code in the returncode
     attribute and output in the output attribute.
 
-    The arguments are the same as for the Popen constructor.  Example:
+    The arguments are the same as for the Popen constructor, including the additional
+    `prefix_name`/`prefix_path` keyword arguments used to select the target conda
+    environment (see :func:`conda_subprocess.process.Popen`).  Example:
 
     >>> check_output(["ls", "-l", "/dev/null"])
     b'crw-rw-rw- 1 root root 1, 3 Oct 18  2007 /dev/null\n'
@@ -129,7 +135,9 @@ def run(
     according to locale encoding, or by "encoding" if set. Text mode is
     triggered by setting any of text, encoding, errors or universal_newlines.
 
-    The other arguments are the same as for the Popen constructor.
+    The other arguments are the same as for the Popen constructor, including the
+    additional `prefix_name`/`prefix_path` keyword arguments used to select the target
+    conda environment (see :func:`conda_subprocess.process.Popen`).
     """
     if input is not None:
         if kwargs.get("stdin") is not None:

--- a/src/conda_subprocess/process.py
+++ b/src/conda_subprocess/process.py
@@ -47,6 +47,26 @@ def Popen(
     text=None,
     umask=-1,
 ):
+    """
+    Execute args in a different conda environment, mirroring the standard library's
+    :class:`subprocess.Popen` interface.
+
+    In addition to the regular :class:`subprocess.Popen` arguments, this accepts:
+
+    Args:
+        prefix_name (str): Name of the conda environment the command should be executed
+            in, e.g. ``"py312"``.
+        prefix_path (str): Absolute path of the conda environment the command should be
+            executed in, e.g. ``"/home/user/mambaforge/envs/py312"``.
+
+    If both `prefix_name` and `prefix_path` are `None`, the currently active conda
+    environment is used. `prefix_path` takes precedence if both are specified.
+
+    The `shell` parameter is not supported - commands are always executed via the conda
+    activation wrapper script, not a shell. The `pipesize` and `process_group`
+    parameters were removed for compatibility with Python 3.9. `env` is merged on top
+    of the current process environment rather than replacing it.
+    """
     # create run script
     script, command = wrap_subprocess_call(
         root_prefix=context.root_prefix,


### PR DESCRIPTION
## Summary
- Add an Installation section to the README (PyPI/conda-forge, `executorlib` extra) and document the default-prefix behavior of the subprocess interface — previously there were no install instructions at all.
- Add/expand docstrings on `Popen`, `call`/`check_call`/`check_output`/`run`, the `@conda` decorator, and `CondaSpawner` to document `prefix_name`/`prefix_path`, since these were copied verbatim from `subprocess` or missing entirely — this is the content that feeds the Sphinx `autosummary` API reference page.
- Replace the bare `autosummary` directive in `docs/api.rst` with a short narrative intro and cross-links to the README/demo notebook.

## Test plan
- [x] Verified the package still imports cleanly and docstrings render (`PYTHONPATH=src python -c "import conda_subprocess; ..."`)
- [x] Ran `tests/test_process.py` against the edited package - passing
- [x] Checked all added docstring lines stay under the project's 88-char line length used elsewhere in the codebase
- [ ] Readthedocs build (will be triggered automatically for this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)